### PR TITLE
Remove unsafe local variables

### DIFF
--- a/kooten-theme.el
+++ b/kooten-theme.el
@@ -628,9 +628,4 @@
 
 (provide-theme 'kooten)
 
-;; Local Variables:
-;; rainbow-mode: t
-;; hl-sexp-mode: nil
-;; End:
-
 ;;; kooten-theme.el ends here


### PR DESCRIPTION
Better to do something like this in your elisp config:

``` el
  (defun sanityinc/enable-rainbow-mode-if-theme ()
    (when (string-match "\\(color-theme-\\|-theme\\.el\\)" (buffer-name))
      (rainbow-mode 1)))

  (add-hook 'emacs-lisp-mode-hook 'sanityinc/enable-rainbow-mode-if-theme)
```
